### PR TITLE
Update unit tests to be compatible with Moodle 3.10+

### DIFF
--- a/tests/observer_test.php
+++ b/tests/observer_test.php
@@ -30,7 +30,7 @@ class local_reset_observer_test extends advanced_testcase {
     /**
      * Initial set up.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         global $CFG;
         require_once($CFG->dirroot . '/my/lib.php');
 

--- a/tests/resetter_test.php
+++ b/tests/resetter_test.php
@@ -39,7 +39,7 @@ class local_reset_dashboard_resetter_test extends advanced_testcase {
     /**
      * Initial set up.
      */
-    protected function setUp() {
+    protected function setUp(): void {
         global $CFG;
         require_once($CFG->dirroot . '/my/lib.php');
 


### PR DESCRIPTION
In Moodle 3.10 - Breaking change: All the "template methods" (setUp(), tearDown()...) now require to return void.
https://github.com/moodle/moodle/blob/master/lib/upgrade.txt#L772